### PR TITLE
Implement subscription system

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use App\UserSubscription;
 
 class Kernel extends ConsoleKernel
 {
@@ -24,7 +25,11 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->call(function () {
+            \App\UserSubscription::where('expires_at', '<', now())
+                ->where('status', 'active')
+                ->update(['status' => 'expired']);
+        })->daily();
     }
 
     /**

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\SubscriptionPlan;
+use App\UserSubscription;
+use Illuminate\Support\Facades\Auth;
+
+class PaymentController extends Controller
+{
+    public function initiate(Request $request)
+    {
+        $plan = SubscriptionPlan::find($request->plan_id);
+        if (!$plan) {
+            return response()->json(['message' => 'Plan not found'], 404);
+        }
+        // Here payment request with Iraqi gateways will be implemented
+        return response()->json(['message' => 'Payment initialization placeholder']);
+    }
+
+    public function webhook(Request $request)
+    {
+        if ($request->status === 'paid') {
+            $plan = SubscriptionPlan::find($request->plan_id);
+            if ($plan) {
+                $starts = now();
+                $expires = $starts->copy()->addDays($plan->duration_days);
+                UserSubscription::create([
+                    'user_id' => $request->user_id,
+                    'plan_id' => $plan->id,
+                    'starts_at' => $starts,
+                    'expires_at' => $expires,
+                    'status' => 'active',
+                ]);
+            }
+        }
+        return response()->json(['message' => 'ok']);
+    }
+}

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\SubscriptionPlan;
+use App\UserSubscription;
+use App\Car;
+use App\CarParts;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class SubscriptionController extends Controller
+{
+    public function getPlans()
+    {
+        return response()->json(SubscriptionPlan::all());
+    }
+
+    public function subscribe(Request $request)
+    {
+        $user = Auth::user();
+        $plan = SubscriptionPlan::find($request->plan_id);
+        if (!$plan) {
+            return response()->json(['message' => 'Plan not found'], 404);
+        }
+        $startsAt = now();
+        $expiresAt = $startsAt->copy()->addDays($plan->duration_days);
+        $subscription = UserSubscription::create([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'starts_at' => $startsAt,
+            'expires_at' => $expiresAt,
+            'status' => 'active',
+        ]);
+        return response()->json($subscription);
+    }
+
+    public function mySubscription()
+    {
+        $user = Auth::user();
+        $sub = UserSubscription::where('user_id', $user->id)
+            ->orderByDesc('starts_at')->first();
+        if (!$sub) {
+            return response()->json(null, 404);
+        }
+        return response()->json($sub);
+    }
+
+    public function myAdsCount()
+    {
+        $user = Auth::user();
+        $sub = UserSubscription::where('user_id', $user->id)
+            ->where('status', 'active')
+            ->orderByDesc('starts_at')
+            ->first();
+        if (!$sub) {
+            return response()->json(['ads_count' => 0, 'ads_limit' => 0, 'remaining' => 0]);
+        }
+        $ads = Car::where('idUser', $user->id)
+            ->whereBetween('created_at', [$sub->starts_at, now()])
+            ->count();
+        $parts = CarParts::where('userID', $user->id)
+            ->whereBetween('created_at', [$sub->starts_at, now()])
+            ->count();
+        $count = $ads + $parts;
+        $limit = $sub->plan->ads_limit;
+        return response()->json([
+            'ads_count' => $count,
+            'ads_limit' => $limit,
+            'remaining' => $limit - $count,
+        ]);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -62,5 +62,6 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'subscription' => \App\Http\Middleware\CheckSubscription::class,
     ];
 }

--- a/app/Http/Middleware/CheckSubscription.php
+++ b/app/Http/Middleware/CheckSubscription.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+use App\UserSubscription;
+use App\Car;
+use App\CarParts;
+
+class CheckSubscription
+{
+    public function handle($request, Closure $next)
+    {
+        $user = Auth::user();
+        if (!$user) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
+        $subscription = UserSubscription::where('user_id', $user->id)
+            ->where('status', 'active')
+            ->where('starts_at', '<=', now())
+            ->where('expires_at', '>=', now())
+            ->orderByDesc('starts_at')
+            ->first();
+
+        if (!$subscription) {
+            return response()->json(['message' => 'Subscription required'], 403);
+        }
+
+        $ads = Car::where('idUser', $user->id)
+            ->whereBetween('created_at', [$subscription->starts_at, now()])
+            ->count();
+        $parts = CarParts::where('userID', $user->id)
+            ->whereBetween('created_at', [$subscription->starts_at, now()])
+            ->count();
+        $total = $ads + $parts;
+
+        if ($total >= $subscription->plan->ads_limit) {
+            return response()->json(['message' => 'Ads limit reached'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/SubscriptionPlan.php
+++ b/app/SubscriptionPlan.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SubscriptionPlan extends Model
+{
+    protected $table = 'subscription_plans';
+    protected $fillable = [
+        'name',
+        'ads_limit',
+        'duration_days',
+        'price'
+    ];
+    public $timestamps = false;
+}

--- a/app/UserSubscription.php
+++ b/app/UserSubscription.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserSubscription extends Model
+{
+    protected $table = 'user_subscriptions';
+    protected $fillable = [
+        'user_id',
+        'plan_id',
+        'starts_at',
+        'expires_at',
+        'status'
+    ];
+    public $timestamps = false;
+
+    public function plan()
+    {
+        return $this->belongsTo(SubscriptionPlan::class, 'plan_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/database/migrations/2025_06_20_000000_create_subscription_plans_table.php
+++ b/database/migrations/2025_06_20_000000_create_subscription_plans_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSubscriptionPlansTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('subscription_plans', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->integer('ads_limit');
+            $table->integer('duration_days');
+            $table->double('price');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('subscription_plans');
+    }
+}

--- a/database/migrations/2025_06_20_000001_create_user_subscriptions_table.php
+++ b/database/migrations/2025_06_20_000001_create_user_subscriptions_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUserSubscriptionsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('user_subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('plan_id');
+            $table->timestamp('starts_at');
+            $table->timestamp('expires_at');
+            $table->string('status');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('user_subscriptions');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,17 @@ Route::middleware([ 'api'])->group(function () {
     Route::post('refresh', 'AuthController@refresh');
     Route::get('me', 'AuthController@me');
 
+    Route::get('subscription-plans', 'SubscriptionController@getPlans');
+    Route::post('subscribe', 'SubscriptionController@subscribe');
+    Route::get('my-subscription', 'SubscriptionController@mySubscription');
+    Route::get('my-ads-count', 'SubscriptionController@myAdsCount');
+
+    Route::post('add-car', 'UserControllers\\CarController@saveCar')->middleware('subscription');
+    Route::post('add-part', 'UserControllers\\CarPartsController@savePart')->middleware('subscription');
+
+    Route::post('payment/initiate', 'PaymentController@initiate');
+    Route::post('payment/webhook', 'PaymentController@webhook');
+
     // Company            ,'middleware'=>'Admin'
     Route::prefix('Company')->group(function (){
         Route::post('save', 'AdminControllers\CompanyController@saveCompany') ;


### PR DESCRIPTION
## Summary
- create `SubscriptionPlan` and `UserSubscription` models with migrations
- add middleware to enforce active subscription and ads limit
- expose subscription management API endpoints
- scaffold payment controller and webhooks
- schedule daily task to expire old subscriptions

## Testing
- `php --version` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554fddb6b8832195652ec3d1df177b